### PR TITLE
Make sure that 301 is never cached

### DIFF
--- a/src/historylinks/middleware.py
+++ b/src/historylinks/middleware.py
@@ -1,6 +1,7 @@
 """Middleware used by the history links service."""
 
 from django.shortcuts import redirect
+from django.views.decorators.cache import never_cache
 
 from historylinks.registration import history_link_context_manager, default_history_link_manager
 
@@ -31,7 +32,7 @@ class HistoryLinkFallbackMiddleware(object):
         if response.status_code == 404:
             redirect_url = default_history_link_manager.get_current_url(request.path)
             if redirect_url and redirect_url != request.path:
-                return redirect(redirect_url, permanent=True)
+                return never_cache(redirect(redirect_url, permanent=True))
         # Return the original response.
         return response
         


### PR DESCRIPTION
Cached permanent redirects are a pain in the ass to undo.

Consider `/blog/slug-a` -> `/blog/slug-b` -> `/blog/slug-a` will result in a redirect loop in the client's browser.
