### PR TITLE
Update to support Django 3.2 and 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,17 @@
 language: python
 sudo: false
 python:
-  - 2.7
-  - 3.5
-  - 3.6
+  - 3.8
+  - 3.9
+  - 3.10
 cache:
   directories:
     - $HOME/.cache/pip
 env:
-  - DJANGO=django==1.8.19
-  - DJANGO=django==1.9.13
-  - DJANGO=django==1.10.8
-  - DJANGO=django==1.11.18
-  - DJANGO=django==2.0.10
-  - DJANGO=django==2.1.5
+  - DJANGO=django==3.2.16
+  - DJANGO=django==4.1.4
 matrix:
   fast_finish: true
-  exclude:
-    - python: 2.7
-      env: DJANGO=django==2.0.10
-    - python: 2.7
-      env: DJANGO=django==2.1.5
 install:
   - travis_retry pip install $DJANGO
   - pip install -e .[test]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "": "src",
     },
     install_requires = [
-        "django>=1.7",
+        "django>=3.2",
     ],
     extras_require = {
         "test": [

--- a/src/historylinks/apps.py
+++ b/src/historylinks/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class HistorylinksConfig(AppConfig):
+    name = 'historylinks'
+    default_auto_field = 'django.db.models.AutoField'

--- a/src/historylinks/middleware.py
+++ b/src/historylinks/middleware.py
@@ -3,10 +3,7 @@ from __future__ import unicode_literals
 
 from django.shortcuts import redirect
 from django.utils.cache import add_never_cache_headers
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = object
+from django.utils.deprecation import MiddlewareMixin
 
 from historylinks.registration import history_link_context_manager, default_history_link_manager
 

--- a/src/historylinks/models.py
+++ b/src/historylinks/models.py
@@ -1,13 +1,9 @@
 """Models used by django-historylinks."""
-from __future__ import unicode_literals
-
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
-from django.utils.encoding import python_2_unicode_compatible
 from django.db import models
 
 
-@python_2_unicode_compatible
 class HistoryLink(models.Model):
 
     """A link to a moved / deleted model."""

--- a/src/historylinks/registration.py
+++ b/src/historylinks/registration.py
@@ -9,8 +9,7 @@ from functools import wraps
 from django.core.signals import request_finished
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_save
-from django.utils import six
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from historylinks.models import HistoryLink
 
@@ -261,9 +260,9 @@ class HistoryLinkManager(object):
         model = obj.__class__
         adapter = self.get_adapter(model)
         content_type = ContentType.objects.get_for_model(model)
-        object_id = force_text(obj.pk)
+        object_id = force_str(obj.pk)
         # Create the history link data.
-        for permalink_name, permalink_value in six.iteritems(adapter.get_permalinks(obj)):
+        for permalink_name, permalink_value in adapter.get_permalinks(obj).items():
             history_link_data = {
                 "permalink": permalink_value,
                 "permalink_name": permalink_name,

--- a/src/tests/test_historylinks/apps.py
+++ b/src/tests/test_historylinks/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TestHistorylinksConfig(AppConfig):
+    name = 'test_historylinks'
+    default_auto_field = 'django.db.models.AutoField'

--- a/src/tests/test_historylinks/tests.py
+++ b/src/tests/test_historylinks/tests.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.urls import reverse
 
 from historylinks import shortcuts as historylinks
 from historylinks.registration import RegistrationError
@@ -29,6 +30,12 @@ class HistoryLinkRedirectTest(TestCase):
         self.obj = HistoryLinkTestModel.objects.create(slug="foo")
         self.obj.slug = "bar"
         self.obj.save()
+
+    def testRaisesException(self):
+        # Ensure coverage of handle_exception in the middleware.
+        with self.assertRaises(AssertionError) as e:
+            self.client.get(reverse('raise_exception'))
+        self.assertEqual(str(e.exception), 'historylinks test')
 
     def testRedirectsToNewURL(self):
         # Try a redirect.

--- a/src/tests/test_historylinks/tests.py
+++ b/src/tests/test_historylinks/tests.py
@@ -34,7 +34,7 @@ class HistoryLinkRedirectTest(TestCase):
         # Try a redirect.
         response = self.client.get("/foo/")
         self.assertEqual(response.status_code, 301)
-        self.assertEqual(response["Location"].replace("http://testserver", ""), "/bar/")
+        self.assertEqual(response["Location"], "/bar/")
         # Try a 404.
         response = self.client.get("/baz/")
         self.assertEqual(response.status_code, 404)

--- a/src/tests/tests/settings.py
+++ b/src/tests/tests/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = (
     "test_historylinks",
 )
 
-MIDDLEWARE = MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/src/tests/tests/settings.py
+++ b/src/tests/tests/settings.py
@@ -92,8 +92,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/src/tests/tests/urls.py
+++ b/src/tests/tests/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 from django.urls import path
 from django.contrib import admin
 
+from tests.views import raise_exception
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('raise-exception/', raise_exception, name='raise_exception')
 ]

--- a/src/tests/tests/urls.py
+++ b/src/tests/tests/urls.py
@@ -13,9 +13,9 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+from django.urls import path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]

--- a/src/tests/tests/views.py
+++ b/src/tests/tests/views.py
@@ -1,0 +1,2 @@
+def raise_exception(request):
+    raise AssertionError('historylinks test')


### PR DESCRIPTION
I have tried to make the commit-by-commit view make sense - please let me know if you would like me to squash.

There isn't any _reasonable_ way that this could support both the ancient versions of Django it supported before _and_ modern ones, which means it also can't support Python 2.x, or anything less than 3.8, so it doesn't.

(The Travis config is a guess. For all I know it might even work! I picked Python versions that are supported by 3.2 and 4.x.)

I shall update the wiki when this is merged.

Thank you for historylinks :)