### PR TITLE
Fix "buildhistorylinks" management command.

### DIFF
--- a/src/historylinks/management/commands/buildhistorylinks.py
+++ b/src/historylinks/management/commands/buildhistorylinks.py
@@ -1,17 +1,15 @@
-from __future__ import unicode_literals
-
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from historylinks.registration import default_history_link_manager, _bulk_save_history_links
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
 
     help = "Builds the history links for all registered models."
 
     @transaction.atomic()
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         verbosity = int(options.get("verbosity", 1))
         link_count = 0
         # Create links.
@@ -22,17 +20,17 @@ class Command(NoArgsCommand):
                 local_link_count += 1
                 links_to_create.extend(default_history_link_manager._update_obj_history_links_iter(obj))
                 if verbosity == 3:
-                    self.stdout.write("Refreshed history link for {obj}.\n".format(
+                    self.stdout.write("Refreshed history link for {obj}.".format(
                         obj=obj,
                     ))
             if verbosity == 2:
-                self.stdout.write("Refreshed {local_link_count} history link(s) for {model}.\n".format(
+                self.stdout.write("Refreshed {local_link_count} history link(s) for {model}.".format(
                     local_link_count=local_link_count,
                     model=model._meta.verbose_name,
                 ))
             link_count += local_link_count
         _bulk_save_history_links(links_to_create)
         if verbosity == 1:
-            self.stdout.write("Refreshed {link_count} history links.\n".format(
+            self.stdout.write("Refreshed {link_count} history links.".format(
                 link_count=link_count,
             ))

--- a/src/tests/test_historylinks/tests.py
+++ b/src/tests/test_historylinks/tests.py
@@ -1,7 +1,12 @@
+from io import StringIO
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 
 from historylinks import shortcuts as historylinks
+from historylinks.models import HistoryLink
 from historylinks.registration import RegistrationError
 from test_historylinks.models import HistoryLinkTestModel
 
@@ -45,6 +50,42 @@ class HistoryLinkRedirectTest(TestCase):
         # Try a 404.
         response = self.client.get("/baz/")
         self.assertEqual(response.status_code, 404)
+
+    def tearDown(self):
+        historylinks.unregister(HistoryLinkTestModel)
+
+
+class HistoryLinkManagementTestCase(TestCase):
+    def test_buildhistorylinks(self):
+        obj = HistoryLinkTestModel.objects.create(slug="foo")
+
+        def assert_historylink_is_sane():
+            self.assertEqual(HistoryLink.objects.all().count(), 1)
+            history_link = HistoryLink.objects.get()
+            self.assertEqual(history_link.content_type, ContentType.objects.get_for_model(HistoryLinkTestModel))
+            self.assertEqual(history_link.object, obj)
+            self.assertEqual(history_link.object_id, str(obj.id))
+            self.assertEqual(history_link.permalink, "/foo/")
+
+        historylinks.register(HistoryLinkTestModel)
+        # sanity check
+        self.assertEqual(HistoryLink.objects.all().count(), 0)
+
+        stdout = StringIO()
+        call_command("buildhistorylinks", stdout=stdout)
+        assert_historylink_is_sane()
+        self.assertEqual(stdout.getvalue(), "Refreshed 1 history links.\n")
+
+        # Ensure the various branches for --verbosity=X are covered.
+        stdout = StringIO()
+        call_command("buildhistorylinks", stdout=stdout, verbosity=2)
+        assert_historylink_is_sane()
+        self.assertEqual(stdout.getvalue(), "Refreshed 1 history link(s) for history link test model.\n")
+
+        stdout = StringIO()
+        call_command("buildhistorylinks", stdout=stdout, verbosity=3)
+        assert_historylink_is_sane()
+        self.assertEqual(stdout.getvalue(), f"Refreshed history link for HistoryLinkTestModel object ({obj.pk}).\n")
 
     def tearDown(self):
         historylinks.unregister(HistoryLinkTestModel)


### PR DESCRIPTION
Me again!

Previously, `buildhistorylinks` was relying on `NoArgsCommand`. This was removed some Django versions ago because `BaseCommand` does the same thing.

While I'm there, add a test for this so it can't get quietly broken again (I probably should have tested this as part of #7, but).

Driveby/noise: `BaseCommand.stdout.write` automatically adds line endings (since at least Django 1.8), so there's no need to do that by hand.