### PR TITLE
Fix HistoryLinkFallbackMiddleware on Django 4.2.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,14 +11,14 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         django-version:
+          - '>=4.2,<4.3'
           - '>=4.1,<4.2'
-          - '>=4.0,<4.1'
           - '>=3.2,<4.0'
         exclude:
           - python-version: 3.7
             django-version: '>=4.1,<4.2'
           - python-version: 3.7
-            django-version: '>=4.0,<4.1'
+            django-version: '>=4.2,<4.3'
           - python-version: '3.10'
             django-version: '>=3.2,<4.0'
           - python-version: '3.11'

--- a/src/historylinks/middleware.py
+++ b/src/historylinks/middleware.py
@@ -7,8 +7,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 from historylinks.registration import history_link_context_manager, default_history_link_manager
 
-
-HISTORYLINK_MIDDLEWARE_FLAG = "historylinks.history_link_fallback_middleware_active"
+HISTORYLINK_MIDDLEWARE_FLAG = "_history_link_fallback_middleware_active"
 
 
 class HistoryLinkFallbackMiddleware(MiddlewareMixin):
@@ -17,13 +16,13 @@ class HistoryLinkFallbackMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """Starts a new history link context."""
-        request.META[(HISTORYLINK_MIDDLEWARE_FLAG, self)] = True
+        setattr(request, HISTORYLINK_MIDDLEWARE_FLAG, True)
         history_link_context_manager.start()
 
     def _close_history_link_context(self, request):
         """Closes the history link context."""
-        if request.META.get((HISTORYLINK_MIDDLEWARE_FLAG, self), False):
-            del request.META[(HISTORYLINK_MIDDLEWARE_FLAG, self)]
+        if getattr(request, HISTORYLINK_MIDDLEWARE_FLAG, False):
+            setattr(request, HISTORYLINK_MIDDLEWARE_FLAG, False)
             history_link_context_manager.end()
 
     def process_response(self, request, response):

--- a/src/tests/tests/views.py
+++ b/src/tests/tests/views.py
@@ -1,2 +1,5 @@
 def raise_exception(request):
+    # Regression test: make sure getting HTTP headers does not throw an
+    # exception.
+    request.headers.get('dontfail')
     raise AssertionError('historylinks test')


### PR DESCRIPTION
Previously, the middleware was (mis?)using request.META to store the flag to determine if it was active or not. This interfered with Django's header handling, e.g. if you did this:

```
request.headers.get('Some-Header')
```

you would get this from deep in the bowels of Django when it saw the tuple which was being used as the key:

```
AttributeError: 'tuple' object has no attribute 'startswith'
```

Instead, let's be less fancy. Set an attribute on the request when the middleware is active, and unset it when it exits. That it no longer adds `self` into the unique key presumably means it'll break some mad use case like running multiple copies of the middleware. Oh well!

While we're there, add 4.2 to the test matrix, and remove the 4.0 series as they are no longer supported. (The GHA conf is a guess. I hope it works!)